### PR TITLE
Updated Readme.md to Clarify Required Headers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ After obtaining an access token with sufficient permissions, queries to the rezS
 
 Each request sent to the API **requires**:
 * A valid "Bearer" token in the `Authorization` header
-* An `X-RezStream-Api-Version` header with the desired version string of the API
+* An additional field in the Headers section with key: `X-RezStream-Api-Version` and value: `<version>`. Note the available versions can be found [here]([url](https://cloudapi.rezstream.com/openapi)) and the value must be a date in "YYYY-MM-DD" format.
 
 ## Versioning
 


### PR DESCRIPTION
In the JSON/YAML files for the API versions the key "X-RezStream-Api-Version" contains a value that is a long alphanumerical text string, however the API call requires the value within the "version" key NOT the value within the "X-RezStream-Api-Version" key while requiring the Header name to be "X-RezStream-Api-Version".